### PR TITLE
feat: inversion selection support for the resource filter on sync and wait app commands

### DIFF
--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -1373,6 +1373,7 @@ const (
 	resourceFieldCount                  = 3
 	resourceFieldNamespaceDelimiter     = "/"
 	resourceFieldNameWithNamespaceCount = 2
+	resourceExcludeIndicator            = "!"
 )
 
 // resource is GROUP:KIND:NAMESPACE/NAME or GROUP:KIND:NAME
@@ -1397,6 +1398,12 @@ func parseSelectedResources(resources []string) ([]*argoappv1.SyncOperationResou
 	}
 
 	for _, resource := range resources {
+		isExcluded := false
+		// check if the resource flag starts with a '!'
+		if strings.HasPrefix(resource, resourceExcludeIndicator) {
+			resource = strings.TrimPrefix(resource, resourceExcludeIndicator)
+			isExcluded = true
+		}
 		fields := strings.Split(resource, resourceFieldDelimiter)
 		if len(fields) != resourceFieldCount {
 			return nil, fmt.Errorf("Resource should have GROUP%sKIND%sNAME, but instead got: %s", resourceFieldDelimiter, resourceFieldDelimiter, resource)
@@ -1410,6 +1417,7 @@ func parseSelectedResources(resources []string) ([]*argoappv1.SyncOperationResou
 			Kind:      fields[1],
 			Name:      name,
 			Namespace: namespace,
+			Exclude:   isExcluded,
 		})
 	}
 	return selectedResources, nil
@@ -1443,6 +1451,16 @@ func NewApplicationWaitCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 
   # Wait for multiple apps
   argocd app wait my-app other-app
+
+  # Wait for apps by resource
+  # Resource should be formatted as GROUP:KIND:NAME. If no GROUP is specified then :KIND:NAME.
+  argocd app wait my-app --resource :Service:my-service
+  argocd app wait my-app --resource argoproj.io:Rollout:my-rollout
+  argocd app wait my-app --resource '!apps:Deployment:my-service'
+  argocd app wait my-app --resource apps:Deployment:my-service --resource :Service:my-service
+  argocd app wait my-app --resource '!*:Service:*'
+  # Specify namespace if the application has resources with the same name in different namespaces
+  argocd app wait my-app --resource argoproj.io:Rollout:my-namespace/my-rollout
 
   # Wait for apps by label, in this example we waiting for apps that are children of another app (aka app-of-apps)
   argocd app wait -l app.kubernetes.io/instance=my-app
@@ -1482,7 +1500,7 @@ func NewApplicationWaitCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 	command.Flags().BoolVar(&watch.suspended, "suspended", false, "Wait for suspended")
 	command.Flags().BoolVar(&watch.degraded, "degraded", false, "Wait for degraded")
 	command.Flags().StringVarP(&selector, "selector", "l", "", "Wait for apps by label. Supports '=', '==', '!=', in, notin, exists & not exists. Matching apps must satisfy all of the specified label constraints.")
-	command.Flags().StringArrayVar(&resources, "resource", []string{}, fmt.Sprintf("Sync only specific resources as GROUP%sKIND%sNAME. Fields may be blank. This option may be specified repeatedly", resourceFieldDelimiter, resourceFieldDelimiter))
+	command.Flags().StringArrayVar(&resources, "resource", []string{}, fmt.Sprintf("Sync only specific resources as GROUP%[1]sKIND%[1]sNAME or %[2]sGROUP%[1]sKIND%[1]sNAME. Fields may be blank and '*' can be used. This option may be specified repeatedly", resourceFieldDelimiter, resourceExcludeIndicator))
 	command.Flags().BoolVar(&watch.operation, "operation", false, "Wait for pending operations")
 	command.Flags().UintVar(&timeout, "timeout", defaultCheckTimeoutSeconds, "Time out after this many seconds")
 	return command
@@ -1542,6 +1560,9 @@ func NewApplicationSyncCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
   # Resource should be formatted as GROUP:KIND:NAME. If no GROUP is specified then :KIND:NAME
   argocd app sync my-app --resource :Service:my-service
   argocd app sync my-app --resource argoproj.io:Rollout:my-rollout
+  argocd app sync my-app --resource '!apps:Deployment:my-service'
+  argocd app sync my-app --resource apps:Deployment:my-service --resource :Service:my-service
+  argocd app sync my-app --resource '!*:Service:*'
   # Specify namespace if the application has resources with the same name in different namespaces
   argocd app sync my-app --resource argoproj.io:Rollout:my-namespace/my-rollout`,
 		Run: func(c *cobra.Command, args []string) {
@@ -1623,15 +1644,25 @@ func NewApplicationSyncCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 				selectedResources, err := parseSelectedResources(resources)
 				errors.CheckError(err)
 
-				var localObjsStrings []string
-				diffOption := &DifferenceOption{}
-				if local != "" {
-					app, err := appIf.Get(ctx, &applicationpkg.ApplicationQuery{
+				var app *argoappv1.Application
+				if local != "" || len(selectedResources) > 0 {
+					app, err = appIf.Get(ctx, &applicationpkg.ApplicationQuery{
 						Name:         &appName,
 						AppNamespace: &appNs,
 					})
 					errors.CheckError(err)
+				}
+				// filters out only those resources that needs to be synced
+				filteredResources := filterAppResources(app, selectedResources)
 
+				// if resources are provided and no app resources match, then return error
+				if len(resources) > 0 && len(filteredResources) == 0 {
+					log.Fatalf("No matching app resources found for resource filter: %v", strings.Join(resources, ", "))
+				}
+
+				var localObjsStrings []string
+				diffOption := &DifferenceOption{}
+				if local != "" {
 					if app.Spec.Source.Plugin != nil && app.Spec.Source.Plugin.Name != "" {
 						log.Warnf(argocommon.ConfigMapPluginCLIDeprecationWarning)
 					}
@@ -1681,7 +1712,7 @@ func NewApplicationSyncCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 					AppNamespace: &appNs,
 					DryRun:       &dryRun,
 					Revision:     &revision,
-					Resources:    selectedResources,
+					Resources:    filteredResources,
 					Prune:        &prune,
 					Manifests:    localObjsStrings,
 					Infos:        getInfos(infos),
@@ -1767,7 +1798,7 @@ func NewApplicationSyncCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 	command.Flags().BoolVar(&dryRun, "dry-run", false, "Preview apply without affecting cluster")
 	command.Flags().BoolVar(&prune, "prune", false, "Allow deleting unexpected resources")
 	command.Flags().StringVar(&revision, "revision", "", "Sync to a specific revision. Preserves parameter overrides")
-	command.Flags().StringArrayVar(&resources, "resource", []string{}, fmt.Sprintf("Sync only specific resources as GROUP%sKIND%sNAME. Fields may be blank. This option may be specified repeatedly", resourceFieldDelimiter, resourceFieldDelimiter))
+	command.Flags().StringArrayVar(&resources, "resource", []string{}, fmt.Sprintf("Sync only specific resources as GROUP%[1]sKIND%[1]sNAME or %[2]sGROUP%[1]sKIND%[1]sNAME. Fields may be blank and '*' can be used. This option may be specified repeatedly", resourceFieldDelimiter, resourceExcludeIndicator))
 	command.Flags().StringVarP(&selector, "selector", "l", "", "Sync apps that match this label. Supports '=', '==', '!=', in, notin, exists & not exists. Matching apps must satisfy all of the specified label constraints.")
 	command.Flags().StringArrayVar(&labels, "label", []string{}, "Sync only specific resources with a label. This option may be specified repeatedly.")
 	command.Flags().UintVar(&timeout, "timeout", defaultCheckTimeoutSeconds, "Time out after this many seconds")
@@ -1892,20 +1923,34 @@ func getResourceStates(app *argoappv1.Application, selectedResources []*argoappv
 	}
 	// filter out not selected resources
 	if len(selectedResources) > 0 {
-		r := []argoappv1.SyncOperationResource{}
-		for _, res := range selectedResources {
-			if res != nil {
-				r = append(r, *res)
-			}
-		}
 		for i := len(states) - 1; i >= 0; i-- {
 			res := states[i]
-			if !argo.ContainsSyncResource(res.Name, res.Namespace, schema.GroupVersionKind{Group: res.Group, Kind: res.Kind}, r) {
+			if !argo.IncludeResource(res.Name, res.Namespace, schema.GroupVersionKind{Group: res.Group, Kind: res.Kind}, selectedResources) {
 				states = append(states[:i], states[i+1:]...)
 			}
 		}
 	}
 	return states
+}
+
+// filterAppResources selects the app resources that match atleast one of the resource filters.
+func filterAppResources(app *argoappv1.Application, selectedResources []*argoappv1.SyncOperationResource) []*argoappv1.SyncOperationResource {
+	var filteredResources []*argoappv1.SyncOperationResource
+	if len(selectedResources) > 0 {
+		for i := range app.Status.Resources {
+			appResource := app.Status.Resources[i]
+			if (argo.IncludeResource(appResource.Name, appResource.Namespace,
+				schema.GroupVersionKind{Group: appResource.Group, Kind: appResource.Kind}, selectedResources)) {
+				filteredResources = append(filteredResources, &argoappv1.SyncOperationResource{
+					Group:     appResource.Group,
+					Kind:      appResource.Kind,
+					Name:      appResource.Name,
+					Namespace: appResource.Namespace,
+				})
+			}
+		}
+	}
+	return filteredResources
 }
 
 func groupResourceStates(app *argoappv1.Application, selectedResources []*argoappv1.SyncOperationResource) map[string]*resourceState {

--- a/docs/user-guide/commands/argocd_app_sync.md
+++ b/docs/user-guide/commands/argocd_app_sync.md
@@ -26,6 +26,9 @@ argocd app sync [APPNAME... | -l selector | --project project-name] [flags]
   # Resource should be formatted as GROUP:KIND:NAME. If no GROUP is specified then :KIND:NAME
   argocd app sync my-app --resource :Service:my-service
   argocd app sync my-app --resource argoproj.io:Rollout:my-rollout
+  argocd app sync my-app --resource '!apps:Deployment:my-service'
+  argocd app sync my-app --resource apps:Deployment:my-service --resource :Service:my-service
+  argocd app sync my-app --resource '!*:Service:*'
   # Specify namespace if the application has resources with the same name in different namespaces
   argocd app sync my-app --resource argoproj.io:Rollout:my-namespace/my-rollout
 ```
@@ -46,7 +49,7 @@ argocd app sync [APPNAME... | -l selector | --project project-name] [flags]
       --project stringArray                   Sync apps that belong to the specified projects. This option may be specified repeatedly.
       --prune                                 Allow deleting unexpected resources
       --replace                               Use a kubectl create/replace instead apply
-      --resource stringArray                  Sync only specific resources as GROUP:KIND:NAME. Fields may be blank. This option may be specified repeatedly
+      --resource stringArray                  Sync only specific resources as GROUP:KIND:NAME or !GROUP:KIND:NAME. Fields may be blank and '*' can be used. This option may be specified repeatedly
       --retry-backoff-duration duration       Retry backoff base duration. Input needs to be a duration (e.g. 2m, 1h) (default 5s)
       --retry-backoff-factor int              Factor multiplies the base duration after each failed retry (default 2)
       --retry-backoff-max-duration duration   Max retry backoff duration. Input needs to be a duration (e.g. 2m, 1h) (default 3m0s)

--- a/docs/user-guide/commands/argocd_app_wait.md
+++ b/docs/user-guide/commands/argocd_app_wait.md
@@ -15,6 +15,16 @@ argocd app wait [APPNAME.. | -l selector] [flags]
   # Wait for multiple apps
   argocd app wait my-app other-app
 
+  # Wait for apps by resource
+  # Resource should be formatted as GROUP:KIND:NAME. If no GROUP is specified then :KIND:NAME.
+  argocd app wait my-app --resource :Service:my-service
+  argocd app wait my-app --resource argoproj.io:Rollout:my-rollout
+  argocd app wait my-app --resource '!apps:Deployment:my-service'
+  argocd app wait my-app --resource apps:Deployment:my-service --resource :Service:my-service
+  argocd app wait my-app --resource '!*:Service:*'
+  # Specify namespace if the application has resources with the same name in different namespaces
+  argocd app wait my-app --resource argoproj.io:Rollout:my-namespace/my-rollout
+
   # Wait for apps by label, in this example we waiting for apps that are children of another app (aka app-of-apps)
   argocd app wait -l app.kubernetes.io/instance=my-app
   argocd app wait -l app.kubernetes.io/instance!=my-app
@@ -30,7 +40,7 @@ argocd app wait [APPNAME.. | -l selector] [flags]
       --health                 Wait for health
   -h, --help                   help for wait
       --operation              Wait for pending operations
-      --resource stringArray   Sync only specific resources as GROUP:KIND:NAME. Fields may be blank. This option may be specified repeatedly
+      --resource stringArray   Sync only specific resources as GROUP:KIND:NAME or !GROUP:KIND:NAME. Fields may be blank and '*' can be used. This option may be specified repeatedly
   -l, --selector string        Wait for apps by label. Supports '=', '==', '!=', in, notin, exists & not exists. Matching apps must satisfy all of the specified label constraints.
       --suspended              Wait for suspended
       --sync                   Wait for sync

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -587,6 +587,8 @@ type SyncOperationResource struct {
 	Kind      string `json:"kind" protobuf:"bytes,2,opt,name=kind"`
 	Name      string `json:"name" protobuf:"bytes,3,opt,name=name"`
 	Namespace string `json:"namespace,omitempty" protobuf:"bytes,4,opt,name=namespace"`
+	// nolint:govet
+	Exclude bool `json:"-"`
 }
 
 // RevisionHistories is a array of history, oldest first and newest last
@@ -609,6 +611,17 @@ func (in RevisionHistories) Trunc(n int) RevisionHistories {
 // HasIdentity determines whether a sync operation is identified by a manifest
 func (r SyncOperationResource) HasIdentity(name string, namespace string, gvk schema.GroupVersionKind) bool {
 	if name == r.Name && gvk.Kind == r.Kind && gvk.Group == r.Group && (r.Namespace == "" || namespace == r.Namespace) {
+		return true
+	}
+	return false
+}
+
+// Compare determines whether an app resource matches the resource filter during sync or wait.
+func (r SyncOperationResource) Compare(name string, namespace string, gvk schema.GroupVersionKind) bool {
+	if (r.Group == "*" || gvk.Group == r.Group) &&
+		(r.Kind == "*" || gvk.Kind == r.Kind) &&
+		(r.Name == "*" || name == r.Name) &&
+		(r.Namespace == "*" || r.Namespace == "" || namespace == r.Namespace) {
 		return true
 	}
 	return false

--- a/util/argo/argo.go
+++ b/util/argo/argo.go
@@ -552,6 +552,21 @@ func ContainsSyncResource(name string, namespace string, gvk schema.GroupVersion
 	return false
 }
 
+// IncludeResource checks if an app resource matches atleast one of the filters, then it returns true.
+func IncludeResource(resourceName string, resourceNamespace string, gvk schema.GroupVersionKind,
+	syncOperationResources []*argoappv1.SyncOperationResource) bool {
+	for _, syncOperationResource := range syncOperationResources {
+		includeResource := syncOperationResource.Compare(resourceName, resourceNamespace, gvk)
+		if syncOperationResource.Exclude {
+			includeResource = !includeResource
+		}
+		if includeResource {
+			return true
+		}
+	}
+	return false
+}
+
 // NormalizeApplicationSpec will normalize an application spec to a preferred state. This is used
 // for migrating application objects which are using deprecated legacy fields into the new fields,
 // and defaulting fields in the spec (e.g. spec.project)

--- a/util/argo/argo_test.go
+++ b/util/argo/argo_test.go
@@ -82,6 +82,129 @@ func TestGetAppProjectWithNoProjDefined(t *testing.T) {
 	assert.Equal(t, proj.Name, projName)
 }
 
+func TestIncludeResource(t *testing.T) {
+	//Resource filters format - GROUP:KIND:NAMESPACE/NAME or GROUP:KIND:NAME
+	var (
+		blankValues = argoappv1.SyncOperationResource{Group: "", Kind: "", Name: "", Namespace: "", Exclude: false}
+		// *:*:*
+		includeAllResources = argoappv1.SyncOperationResource{Group: "*", Kind: "*", Name: "*", Namespace: "", Exclude: false}
+		// !*:*:*
+		excludeAllResources = argoappv1.SyncOperationResource{Group: "*", Kind: "*", Name: "*", Namespace: "", Exclude: true}
+		// *:Service:*
+		includeAllServiceResources = argoappv1.SyncOperationResource{Group: "*", Kind: "Service", Name: "*", Namespace: "", Exclude: false}
+		// !*:Service:*
+		excludeAllServiceResources = argoappv1.SyncOperationResource{Group: "*", Kind: "Service", Name: "*", Namespace: "", Exclude: true}
+		// apps:ReplicaSet:backend
+		includeReplicaSetResource = argoappv1.SyncOperationResource{Group: "apps", Kind: "ReplicaSet", Name: "backend", Namespace: "", Exclude: false}
+		// !apps:ReplicaSet:backend
+		excludeReplicaSetResource = argoappv1.SyncOperationResource{Group: "apps", Kind: "ReplicaSet", Name: "backend", Namespace: "", Exclude: true}
+	)
+	tests := []struct {
+		testName              string
+		name                  string
+		namespace             string
+		gvk                   schema.GroupVersionKind
+		syncOperationResource []*argoappv1.SyncOperationResource
+		expectedResult        bool
+	}{
+		//--resource apps:ReplicaSet:backend --resource *:Service:*
+		{testName: "Include ReplicaSet backend resouce and all service resources",
+			name:                  "backend",
+			namespace:             "default",
+			gvk:                   schema.GroupVersionKind{Group: "apps", Kind: "ReplicaSet"},
+			syncOperationResource: []*argoappv1.SyncOperationResource{&includeAllServiceResources, &includeReplicaSetResource},
+			expectedResult:        true,
+		},
+		//--resource apps:ReplicaSet:backend --resource *:Service:*
+		{testName: "Include ReplicaSet backend resouce and all service resources",
+			name:                  "main-page-down",
+			namespace:             "default",
+			gvk:                   schema.GroupVersionKind{Group: "batch", Kind: "Job"},
+			syncOperationResource: []*argoappv1.SyncOperationResource{&includeAllServiceResources, &includeReplicaSetResource},
+			expectedResult:        false,
+		},
+		//--resource apps:ReplicaSet:backend --resource !*:Service:*
+		{testName: "Include ReplicaSet backend resouce and exclude all service resources",
+			name:                  "main-page-down",
+			namespace:             "default",
+			gvk:                   schema.GroupVersionKind{Group: "batch", Kind: "Job"},
+			syncOperationResource: []*argoappv1.SyncOperationResource{&excludeAllServiceResources, &includeReplicaSetResource},
+			expectedResult:        true,
+		},
+		// --resource !apps:ReplicaSet:backend --resource !*:Service:*
+		{testName: "Exclude ReplicaSet backend resouce and all service resources",
+			name:                  "main-page-down",
+			namespace:             "default",
+			gvk:                   schema.GroupVersionKind{Group: "batch", Kind: "Job"},
+			syncOperationResource: []*argoappv1.SyncOperationResource{&excludeReplicaSetResource, &excludeAllServiceResources},
+			expectedResult:        true,
+		},
+		// --resource !apps:ReplicaSet:backend
+		{testName: "Exclude ReplicaSet backend resouce",
+			name:                  "backend",
+			namespace:             "default",
+			gvk:                   schema.GroupVersionKind{Group: "apps", Kind: "ReplicaSet"},
+			syncOperationResource: []*argoappv1.SyncOperationResource{&excludeReplicaSetResource},
+			expectedResult:        false,
+		},
+		// --resource apps:ReplicaSet:backend
+		{testName: "Include ReplicaSet backend resouce",
+			name:                  "backend",
+			namespace:             "default",
+			gvk:                   schema.GroupVersionKind{Group: "apps", Kind: "ReplicaSet"},
+			syncOperationResource: []*argoappv1.SyncOperationResource{&includeReplicaSetResource},
+			expectedResult:        true,
+		},
+		// --resource !*:Service:*
+		{testName: "Exclude Service resouces",
+			name:                  "backend",
+			namespace:             "default",
+			gvk:                   schema.GroupVersionKind{Group: "", Kind: "Service"},
+			syncOperationResource: []*argoappv1.SyncOperationResource{&excludeAllServiceResources},
+			expectedResult:        false,
+		},
+		// --resource *:Service:*
+		{testName: "Include Service resouces",
+			name:                  "backend",
+			namespace:             "default",
+			gvk:                   schema.GroupVersionKind{Group: "", Kind: "Service"},
+			syncOperationResource: []*argoappv1.SyncOperationResource{&includeAllServiceResources},
+			expectedResult:        true,
+		},
+		// --resource !*:*:*
+		{testName: "Exclude all resouces",
+			name:                  "backend",
+			namespace:             "default",
+			gvk:                   schema.GroupVersionKind{Group: "", Kind: "Service"},
+			syncOperationResource: []*argoappv1.SyncOperationResource{&excludeAllResources},
+			expectedResult:        false,
+		},
+		// --resource *:*:*
+		{testName: "Include all resouces",
+			name:                  "backend",
+			namespace:             "default",
+			gvk:                   schema.GroupVersionKind{Group: "", Kind: "Service"},
+			syncOperationResource: []*argoappv1.SyncOperationResource{&includeAllResources},
+			expectedResult:        true,
+		},
+		{testName: "No Filters",
+			name:                  "backend",
+			namespace:             "default",
+			gvk:                   schema.GroupVersionKind{Group: "", Kind: "Service"},
+			syncOperationResource: []*argoappv1.SyncOperationResource{&blankValues},
+			expectedResult:        false,
+		},
+		{testName: "Default values"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			isResourceIncluded := IncludeResource(test.name, test.namespace, test.gvk, test.syncOperationResource)
+			assert.Equal(t, test.expectedResult, isResourceIncluded)
+		})
+	}
+}
+
 func TestContainsSyncResource(t *testing.T) {
 	var (
 		blankUnstructured unstructured.Unstructured


### PR DESCRIPTION
This PR resolves the --resource flag enhancement of the issue.

Sync and Wait commands to manage applications can now be filtered with negative selection of the resources. Matching app resources that satisfy atleast one of the resource filter condition will be selected. 

Examples of the inversion filter are:

argocd app wait my-app --resource '!apps:Deployment:my-service'
argocd app sync my-app --resource '!*:Deployment:*'

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

