### PR TITLE
feat: Edit cluster command

### DIFF
--- a/cmd/argocd/commands/completion.go
+++ b/cmd/argocd/commands/completion.go
@@ -146,6 +146,7 @@ __argocd_custom_func() {
 			;;
 		argocd_cluster_get | \
 		argocd_cluster_rm | \
+		argocd_cluster_edit | \
 		argocd_login | \
 		argocd_cluster_add)
 			__argocd_list_servers

--- a/docs/user-guide/commands/argocd_cluster.md
+++ b/docs/user-guide/commands/argocd_cluster.md
@@ -21,6 +21,9 @@ argocd cluster [flags]
   # Remove a target cluster context from ArgoCD
   argocd cluster rm example-cluster
 
+  # Edit a target cluster context from ArgoCD
+  argocd cluster edit cluster-name --name new-cluster-name --namespaces all
+  argocd cluster edit cluster-name --name new-cluster-name --namespaces namespace-one,namespace-two
 ```
 
 ### Options
@@ -74,6 +77,7 @@ argocd cluster [flags]
 
 * [argocd](argocd.md)	 - argocd controls a Argo CD server
 * [argocd cluster add](argocd_cluster_add.md)	 - argocd cluster add CONTEXT
+* [argocd cluster edit](argocd_cluster_edit.md)	 - Edit cluster information
 * [argocd cluster get](argocd_cluster_get.md)	 - Get cluster information
 * [argocd cluster list](argocd_cluster_list.md)	 - List configured clusters
 * [argocd cluster rm](argocd_cluster_rm.md)	 - Remove cluster credentials

--- a/docs/user-guide/commands/argocd_cluster_edit.md
+++ b/docs/user-guide/commands/argocd_cluster_edit.md
@@ -1,0 +1,51 @@
+## argocd cluster edit
+
+Edit cluster information
+
+```
+argocd cluster edit cluster name [flags]
+```
+
+### Examples
+
+```
+  # Edit cluster information
+  argocd cluster edit cluster-name --name new-cluster-name --namespaces all
+  argocd cluster edit cluster-name --name new-cluster-name --namespaces namespace-one,namespace-two
+```
+
+### Options
+
+```
+  -h, --help                     help for edit
+      --name string              Overwrite the cluster name
+      --namespaces stringArray   List of namespaces which are allowed to manage. Specify 'all' to manage all namespaces
+```
+
+### Options inherited from parent commands
+
+```
+      --auth-token string               Authentication token
+      --client-crt string               Client certificate file
+      --client-crt-key string           Client certificate key file
+      --config string                   Path to Argo CD config (default "/home/user/.config/argocd/config")
+      --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
+      --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
+      --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
+  -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
+      --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
+      --insecure                        Skip server certificate and domain verification
+      --kube-context string             Directs the command to the given kube-context
+      --logformat string                Set the logging format. One of: text|json (default "text")
+      --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
+      --plaintext                       Disable TLS
+      --port-forward                    Connect to a random argocd-server port using port forwarding
+      --port-forward-namespace string   Namespace name which should be used for port forwarding
+      --server string                   Argo CD server address
+      --server-crt string               Server certificate file
+```
+
+### SEE ALSO
+
+* [argocd cluster](argocd_cluster.md)	 - Manage cluster credentials
+

--- a/test/e2e/cluster_test.go
+++ b/test/e2e/cluster_test.go
@@ -133,6 +133,25 @@ func TestClusterListDenied(t *testing.T) {
 		})
 }
 
+func TestClusterEdit(t *testing.T) {
+	EnsureCleanState(t)
+	defer RecordTestRun(t)
+	clusterFixture.
+		GivenWithSameState(t).
+		Project(ProjectName).
+		Name("in-cluster").
+		Namespaces([]string{"namespace-edit-1", "namespace-edit-2"}).
+		Server(KubernetesInternalAPIServerAddr).
+		When().
+		UpdateNamespaces().
+		GetByName("in-cluster").
+		Then().
+		AndCLIOutput(func(output string, err error) {
+			assert.True(t, strings.Contains(output, "namespace-edit-1"))
+			assert.True(t, strings.Contains(output, "namespace-edit-2"))
+		})
+}
+
 func TestClusterGet(t *testing.T) {
 	SkipIfAlreadyRun(t)
 	EnsureCleanState(t)

--- a/test/e2e/fixture/cluster/actions.go
+++ b/test/e2e/fixture/cluster/actions.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/argoproj/argo-cd/v2/common"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
@@ -100,6 +101,18 @@ func (a *Actions) List() *Actions {
 func (a *Actions) Get() *Actions {
 	a.context.t.Helper()
 	a.runCli("cluster", "get", a.context.server)
+	return a
+}
+
+func (a *Actions) GetByName(name string) *Actions {
+	a.context.t.Helper()
+	a.runCli("cluster", "get", name)
+	return a
+}
+
+func (a *Actions) UpdateNamespaces() *Actions {
+	a.context.t.Helper()
+	a.runCli("cluster", "edit", a.context.name, "--namespaces", strings.Join(a.context.namespaces, ","))
 	return a
 }
 

--- a/test/e2e/fixture/cluster/context.go
+++ b/test/e2e/fixture/cluster/context.go
@@ -12,11 +12,12 @@ import (
 type Context struct {
 	t *testing.T
 	// seconds
-	timeout int
-	name    string
-	project string
-	server  string
-	upsert  bool
+	timeout    int
+	name       string
+	project    string
+	server     string
+	upsert     bool
+	namespaces []string
 }
 
 func Given(t *testing.T) *Context {
@@ -42,6 +43,11 @@ func (c *Context) Name(name string) *Context {
 
 func (c *Context) Server(server string) *Context {
 	c.server = server
+	return c
+}
+
+func (c *Context) Namespaces(namespaces []string) *Context {
+	c.namespaces = namespaces
 	return c
 }
 


### PR DESCRIPTION
Closes the Issue. New edit cluster command has been implemented, using which the name and the namespaces can be updated.

Example:
argocd cluster edit cluster-name --name new-cluster-name --namespaces all
argocd cluster edit cluster-name --name new-cluster-name --namespaces namespace-one,namespace-two`

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

