### PR TITLE
Pull request labels exposed in Pull Request generator template

### DIFF
--- a/applicationset/examples/pull-request-generator/pull-request-example.yaml
+++ b/applicationset/examples/pull-request-generator/pull-request-example.yaml
@@ -23,6 +23,8 @@ spec:
   template:
     metadata:
       name: 'myapp-{{ .branch }}-{{ .number }}'
+      labels:
+        key1: '{{ index .labels 0 }}'
     spec:
       source:
         repoURL: 'https://github.com/myorg/myrepo.git'

--- a/applicationset/generators/pull_request.go
+++ b/applicationset/generators/pull_request.go
@@ -90,13 +90,19 @@ func (g *PullRequestGenerator) GenerateParams(appSetGenerator *argoprojiov1alpha
 			shortSHALength = len(pull.HeadSHA)
 		}
 
-		params = append(params, map[string]interface{}{
+		paramMap := map[string]interface{}{
 			"number":         strconv.Itoa(pull.Number),
 			"branch":         pull.Branch,
 			"branch_slug":    slug.Make(pull.Branch),
 			"head_sha":       pull.HeadSHA,
 			"head_short_sha": pull.HeadSHA[:shortSHALength],
-		})
+		}
+
+		// PR lables will only be supported for Go Template appsets, since fasttemplate will be deprecated.
+		if applicationSetInfo != nil && applicationSetInfo.Spec.GoTemplate {
+			paramMap["labels"] = pull.Labels
+		}
+		params = append(params, paramMap)
 	}
 	return params, nil
 }

--- a/applicationset/generators/pull_request_test.go
+++ b/applicationset/generators/pull_request_test.go
@@ -17,9 +17,10 @@ import (
 func TestPullRequestGithubGenerateParams(t *testing.T) {
 	ctx := context.Background()
 	cases := []struct {
-		selectFunc  func(context.Context, *argoprojiov1alpha1.PullRequestGenerator, *argoprojiov1alpha1.ApplicationSet) (pullrequest.PullRequestService, error)
-		expected    []map[string]interface{}
-		expectedErr error
+		selectFunc     func(context.Context, *argoprojiov1alpha1.PullRequestGenerator, *argoprojiov1alpha1.ApplicationSet) (pullrequest.PullRequestService, error)
+		expected       []map[string]interface{}
+		expectedErr    error
+		applicationSet argoprojiov1alpha1.ApplicationSet
 	}{
 		{
 			selectFunc: func(context.Context, *argoprojiov1alpha1.PullRequestGenerator, *argoprojiov1alpha1.ApplicationSet) (pullrequest.PullRequestService, error) {
@@ -107,6 +108,71 @@ func TestPullRequestGithubGenerateParams(t *testing.T) {
 			expected:    nil,
 			expectedErr: fmt.Errorf("error listing repos: fake error"),
 		},
+		{
+			selectFunc: func(context.Context, *argoprojiov1alpha1.PullRequestGenerator, *argoprojiov1alpha1.ApplicationSet) (pullrequest.PullRequestService, error) {
+				return pullrequest.NewFakeService(
+					ctx,
+					[]*pullrequest.PullRequest{
+						&pullrequest.PullRequest{
+							Number:  1,
+							Branch:  "branch1",
+							HeadSHA: "089d92cbf9ff857a39e6feccd32798ca700fb958",
+							Labels:  []string{"preview"},
+						},
+					},
+					nil,
+				)
+			},
+			expected: []map[string]interface{}{
+				{
+					"number":         "1",
+					"branch":         "branch1",
+					"branch_slug":    "branch1",
+					"head_sha":       "089d92cbf9ff857a39e6feccd32798ca700fb958",
+					"head_short_sha": "089d92cb",
+					"labels":         []string{"preview"},
+				},
+			},
+			expectedErr: nil,
+			applicationSet: argoprojiov1alpha1.ApplicationSet{
+				Spec: argoprojiov1alpha1.ApplicationSetSpec{
+					// Application set is using Go Template.
+					GoTemplate: true,
+				},
+			},
+		},
+		{
+			selectFunc: func(context.Context, *argoprojiov1alpha1.PullRequestGenerator, *argoprojiov1alpha1.ApplicationSet) (pullrequest.PullRequestService, error) {
+				return pullrequest.NewFakeService(
+					ctx,
+					[]*pullrequest.PullRequest{
+						&pullrequest.PullRequest{
+							Number:  1,
+							Branch:  "branch1",
+							HeadSHA: "089d92cbf9ff857a39e6feccd32798ca700fb958",
+							Labels:  []string{"preview"},
+						},
+					},
+					nil,
+				)
+			},
+			expected: []map[string]interface{}{
+				{
+					"number":         "1",
+					"branch":         "branch1",
+					"branch_slug":    "branch1",
+					"head_sha":       "089d92cbf9ff857a39e6feccd32798ca700fb958",
+					"head_short_sha": "089d92cb",
+				},
+			},
+			expectedErr: nil,
+			applicationSet: argoprojiov1alpha1.ApplicationSet{
+				Spec: argoprojiov1alpha1.ApplicationSetSpec{
+					// Application set is using fasttemplate.
+					GoTemplate: false,
+				},
+			},
+		},
 	}
 
 	for _, c := range cases {
@@ -117,7 +183,7 @@ func TestPullRequestGithubGenerateParams(t *testing.T) {
 			PullRequest: &argoprojiov1alpha1.PullRequestGenerator{},
 		}
 
-		got, gotErr := gen.GenerateParams(&generatorConfig, nil)
+		got, gotErr := gen.GenerateParams(&generatorConfig, &c.applicationSet)
 		assert.Equal(t, c.expectedErr, gotErr)
 		assert.ElementsMatch(t, c.expected, got)
 	}

--- a/applicationset/services/pull_request/bitbucket_server.go
+++ b/applicationset/services/pull_request/bitbucket_server.go
@@ -69,6 +69,7 @@ func (b *BitbucketService) List(_ context.Context) ([]*PullRequest, error) {
 				Number:  pull.ID,
 				Branch:  pull.FromRef.DisplayID,    // ID: refs/heads/main DisplayID: main
 				HeadSHA: pull.FromRef.LatestCommit, // This is not defined in the official docs, but works in practice
+				Labels:  []string{},                // Not supported by library
 			})
 		}
 

--- a/applicationset/services/pull_request/bitbucket_server_test.go
+++ b/applicationset/services/pull_request/bitbucket_server_test.go
@@ -122,16 +122,19 @@ func TestListPullRequestPagination(t *testing.T) {
 		Number:  101,
 		Branch:  "feature-101",
 		HeadSHA: "ab3cf2e4d1517c83e720d2585b9402dbef71f992",
+		Labels:  []string{},
 	}, *pullRequests[0])
 	assert.Equal(t, PullRequest{
 		Number:  102,
 		Branch:  "feature-102",
 		HeadSHA: "bb3cf2e4d1517c83e720d2585b9402dbef71f992",
+		Labels:  []string{},
 	}, *pullRequests[1])
 	assert.Equal(t, PullRequest{
 		Number:  200,
 		Branch:  "feature-200",
 		HeadSHA: "cb3cf2e4d1517c83e720d2585b9402dbef71f992",
+		Labels:  []string{},
 	}, *pullRequests[2])
 }
 
@@ -284,11 +287,13 @@ func TestListPullRequestBranchMatch(t *testing.T) {
 		Number:  101,
 		Branch:  "feature-101",
 		HeadSHA: "ab3cf2e4d1517c83e720d2585b9402dbef71f992",
+		Labels:  []string{},
 	}, *pullRequests[0])
 	assert.Equal(t, PullRequest{
 		Number:  102,
 		Branch:  "feature-102",
 		HeadSHA: "bb3cf2e4d1517c83e720d2585b9402dbef71f992",
+		Labels:  []string{},
 	}, *pullRequests[1])
 
 	regexp = `.*2$`
@@ -305,6 +310,7 @@ func TestListPullRequestBranchMatch(t *testing.T) {
 		Number:  102,
 		Branch:  "feature-102",
 		HeadSHA: "bb3cf2e4d1517c83e720d2585b9402dbef71f992",
+		Labels:  []string{},
 	}, *pullRequests[0])
 
 	regexp = `[\d{2}`

--- a/applicationset/services/pull_request/gitea.go
+++ b/applicationset/services/pull_request/gitea.go
@@ -57,7 +57,17 @@ func (g *GiteaService) List(ctx context.Context) ([]*PullRequest, error) {
 			Number:  int(pr.Index),
 			Branch:  pr.Head.Ref,
 			HeadSHA: pr.Head.Sha,
+			Labels:  getGiteaPRLabelNames(pr.Labels),
 		})
 	}
 	return list, nil
+}
+
+// Get the Gitea pull request label names.
+func getGiteaPRLabelNames(giteaLabels []*gitea.Label) []string {
+	var labelNames []string
+	for _, giteaLabel := range giteaLabels {
+		labelNames = append(labelNames, giteaLabel.Name)
+	}
+	return labelNames
 }

--- a/applicationset/services/pull_request/gitea_test.go
+++ b/applicationset/services/pull_request/gitea_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"code.gitea.io/sdk/gitea"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -256,4 +257,33 @@ func TestGiteaList(t *testing.T) {
 	assert.Equal(t, prs[0].Number, 1)
 	assert.Equal(t, prs[0].Branch, "test")
 	assert.Equal(t, prs[0].HeadSHA, "7bbaf62d92ddfafd9cc8b340c619abaec32bc09f")
+}
+
+func TestGetGiteaPRLabelNames(t *testing.T) {
+	Tests := []struct {
+		Name           string
+		PullLabels     []*gitea.Label
+		ExpectedResult []string
+	}{
+		{
+			Name: "PR has labels",
+			PullLabels: []*gitea.Label{
+				&gitea.Label{Name: "label1"},
+				&gitea.Label{Name: "label2"},
+				&gitea.Label{Name: "label3"},
+			},
+			ExpectedResult: []string{"label1", "label2", "label3"},
+		},
+		{
+			Name:           "PR does not have labels",
+			PullLabels:     []*gitea.Label{},
+			ExpectedResult: nil,
+		},
+	}
+	for _, test := range Tests {
+		t.Run(test.Name, func(t *testing.T) {
+			labels := getGiteaPRLabelNames(test.PullLabels)
+			assert.Equal(t, test.ExpectedResult, labels)
+		})
+	}
 }

--- a/applicationset/services/pull_request/github.go
+++ b/applicationset/services/pull_request/github.go
@@ -68,6 +68,7 @@ func (g *GithubService) List(ctx context.Context) ([]*PullRequest, error) {
 				Number:  *pull.Number,
 				Branch:  *pull.Head.Ref,
 				HeadSHA: *pull.Head.SHA,
+				Labels:  getGithubPRLabelNames(pull.Labels),
 			})
 		}
 		if resp.NextPage == 0 {
@@ -96,4 +97,13 @@ func containLabels(expectedLabels []string, gotLabels []*github.Label) bool {
 		}
 	}
 	return true
+}
+
+// Get the Github pull request label names.
+func getGithubPRLabelNames(gitHubLabels []*github.Label) []string {
+	var labelNames []string
+	for _, gitHubLabel := range gitHubLabels {
+		labelNames = append(labelNames, *gitHubLabel.Name)
+	}
+	return labelNames
 }

--- a/applicationset/services/pull_request/github_test.go
+++ b/applicationset/services/pull_request/github_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/google/go-github/v35/github"
+	"github.com/stretchr/testify/assert"
 )
 
 func toPtr(s string) *string {
@@ -54,6 +55,35 @@ func TestContainLabels(t *testing.T) {
 			if got := containLabels(c.Labels, c.PullLabels); got != c.Expect {
 				t.Errorf("expect: %v, got: %v", c.Expect, got)
 			}
+		})
+	}
+}
+
+func TestGetGitHubPRLabelNames(t *testing.T) {
+	Tests := []struct {
+		Name           string
+		PullLabels     []*github.Label
+		ExpectedResult []string
+	}{
+		{
+			Name: "PR has labels",
+			PullLabels: []*github.Label{
+				&github.Label{Name: toPtr("label1")},
+				&github.Label{Name: toPtr("label2")},
+				&github.Label{Name: toPtr("label3")},
+			},
+			ExpectedResult: []string{"label1", "label2", "label3"},
+		},
+		{
+			Name:           "PR does not have labels",
+			PullLabels:     []*github.Label{},
+			ExpectedResult: nil,
+		},
+	}
+	for _, test := range Tests {
+		t.Run(test.Name, func(t *testing.T) {
+			labels := getGithubPRLabelNames(test.PullLabels)
+			assert.Equal(t, test.ExpectedResult, labels)
 		})
 	}
 }

--- a/applicationset/services/pull_request/gitlab.go
+++ b/applicationset/services/pull_request/gitlab.go
@@ -72,6 +72,7 @@ func (g *GitLabService) List(ctx context.Context) ([]*PullRequest, error) {
 				Number:  mr.IID,
 				Branch:  mr.SourceBranch,
 				HeadSHA: mr.SHA,
+				Labels:  mr.Labels,
 			})
 		}
 		if resp.NextPage == 0 {

--- a/applicationset/services/pull_request/interface.go
+++ b/applicationset/services/pull_request/interface.go
@@ -12,6 +12,8 @@ type PullRequest struct {
 	Branch string
 	// HeadSHA is the SHA of the HEAD from which the pull request originated.
 	HeadSHA string
+	// Labels of the pull request.
+	Labels []string
 }
 
 type PullRequestService interface {

--- a/docs/operator-manual/applicationset/Generators-Pull-Request.md
+++ b/docs/operator-manual/applicationset/Generators-Pull-Request.md
@@ -274,6 +274,7 @@ spec:
 * `branch_slug`: The branch name will be cleaned to be conform to the DNS label standard as defined in [RFC 1123](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names), and truncated to 50 characters to give room to append/suffix-ing it with 13 more characters.
 * `head_sha`: This is the SHA of the head of the pull request.
 * `head_short_sha`: This is the short SHA of the head of the pull request (8 characters long or the length of the head SHA if it's shorter).
+* `labels`: The array of pull request labels. (Supported only for Go Template ApplicationSet manifests.)
 
 ## Webhook Configuration
 

--- a/test/e2e/applicationset_test.go
+++ b/test/e2e/applicationset_test.go
@@ -1141,6 +1141,7 @@ func TestSimplePullRequestGeneratorGoTemplate(t *testing.T) {
 			Name:       "guestbook-1",
 			Namespace:  utils.ArgoCDNamespace,
 			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+			Labels:     map[string]string{"app": "preview"},
 		},
 		Spec: argov1alpha1.ApplicationSpec{
 			Project: "default",
@@ -1167,7 +1168,9 @@ func TestSimplePullRequestGeneratorGoTemplate(t *testing.T) {
 		Spec: v1alpha1.ApplicationSetSpec{
 			GoTemplate: true,
 			Template: v1alpha1.ApplicationSetTemplate{
-				ApplicationSetTemplateMeta: v1alpha1.ApplicationSetTemplateMeta{Name: "guestbook-{{ .number }}"},
+				ApplicationSetTemplateMeta: v1alpha1.ApplicationSetTemplateMeta{
+					Name:   "guestbook-{{ .number }}",
+					Labels: map[string]string{"app": "{{index .labels 0}}"}},
 				Spec: argov1alpha1.ApplicationSpec{
 					Project: "default",
 					Source: argov1alpha1.ApplicationSource{


### PR DESCRIPTION
Pull request labels have been exposed in Pull Request generator templates for Github, Gitea & Gitlab.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

